### PR TITLE
Feature/#111 kakao social login

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,7 @@ android {
             useSupportLibrary true
         }
         manifestPlaceholders = [ MAPS_API_KEY:"${properties.getProperty('MAPS_API_KEY')}"]
+        buildConfigField "String", "KAKAO_NATIVE_APPKEY", properties['KAKAO_NATIVE_APPKEY']
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,8 +126,17 @@ dependencies {
     implementation "com.google.accompanist:accompanist-pager:0.24.13-rc"
     implementation "com.google.accompanist:accompanist-pager-indicators:0.24.13-rc"
 
-    //systemuicontroller
+    // system ui controller
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.17.0"
+
+    // kakao sdk
+    implementation "com.kakao.sdk:v2-all:2.11.2" // 전체 모듈 설치, 2.11.0 버전부터 지원
+//    implementation "com.kakao.sdk:v2-user:2.11.2" // 카카오 로그인
+//    implementation "com.kakao.sdk:v2-talk:2.11.2" // 친구, 메시지(카카오톡)
+//    implementation "com.kakao.sdk:v2-story:2.11.2" // 카카오스토리
+//    implementation "com.kakao.sdk:v2-share:2.11.2" // 메시지(카카오톡 공유)
+//    implementation "com.kakao.sdk:v2-navi:2.11.2" // 카카오내비
+//    implementation "com.kakao.sdk:v2-friend:2.11.2" // 카카오톡 소셜 피커, 리소스 번들 파일 포함
 }
 
 kapt {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,20 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="kakao${KAKAO_NATIVE_APPKEY}" />
+            </intent-filter>
+        </activity>
+
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${MAPS_API_KEY}" />

--- a/app/src/main/java/com/d_vide/D_VIDE/DivideApplication.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/DivideApplication.kt
@@ -1,7 +1,14 @@
 package com.d_vide.D_VIDE
 
 import android.app.Application
+import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class DivideApplication : Application()
+class DivideApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        // Kakao SDK 초기화
+        KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APPKEY)
+    }
+}

--- a/app/src/main/java/com/d_vide/D_VIDE/app/data/remote/UserApi.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/data/remote/UserApi.kt
@@ -1,5 +1,6 @@
 package com.d_vide.D_VIDE.app.data.remote
 
+import com.d_vide.D_VIDE.app.data.remote.requestDTO.AccessToken
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.BadgeRequestDTO
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.EmailPasswordDTO
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.UserIdDTO
@@ -12,6 +13,11 @@ interface UserApi {
     @POST("/api/v1/auth/login")
     suspend fun login(
         @Body emailPw: EmailPasswordDTO
+    ): Response<IdentificationDTO>
+
+    @POST("/api/v1/auth/kakao")
+    suspend fun kakaoLogin(
+        @Body accessToken: AccessToken
     ): Response<IdentificationDTO>
 
     @GET("/api/v1/user")

--- a/app/src/main/java/com/d_vide/D_VIDE/app/data/remote/requestDTO/AccessToken.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/data/remote/requestDTO/AccessToken.kt
@@ -1,0 +1,6 @@
+package com.d_vide.D_VIDE.app.data.remote.requestDTO
+
+
+data class AccessToken(
+    val accessToken: String = ""
+)

--- a/app/src/main/java/com/d_vide/D_VIDE/app/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/data/repository/UserRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.d_vide.D_VIDE.app.data.repository
 
 import com.d_vide.D_VIDE.app.data.remote.UserApi
+import com.d_vide.D_VIDE.app.data.remote.requestDTO.AccessToken
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.BadgeRequestDTO
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.EmailPasswordDTO
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.UserIdDTO
@@ -21,6 +22,10 @@ class UserRepositoryImpl @Inject constructor(
 ) : UserRepository {
     override suspend fun doLogin(emailPw: EmailPasswordDTO): Response<IdentificationDTO> {
         return api.login(emailPw)
+    }
+
+    override suspend fun doKakaoLogin(token: String): Response<IdentificationDTO> {
+        return api.kakaoLogin(AccessToken(token))
     }
 
     override suspend fun getUserInfo(): Response<UserDTO> {

--- a/app/src/main/java/com/d_vide/D_VIDE/app/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/domain/repository/UserRepository.kt
@@ -9,6 +9,8 @@ import retrofit2.Response
 interface UserRepository {
 
     suspend fun doLogin(emailPw: EmailPasswordDTO): Response<IdentificationDTO>
+    suspend fun doKakaoLogin(token: String): Response<IdentificationDTO>
+
     suspend fun getUserInfo(): Response<UserDTO>
 
     fun getUserToken(): String

--- a/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/Login/DoKakaoLogin.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/Login/DoKakaoLogin.kt
@@ -1,0 +1,32 @@
+package com.d_vide.D_VIDE.app.domain.use_case.Login
+
+import com.d_vide.D_VIDE.app.data.remote.responseDTO.IdentificationDTO
+import com.d_vide.D_VIDE.app.domain.repository.UserRepository
+import com.d_vide.D_VIDE.app.domain.util.Resource
+import com.d_vide.D_VIDE.app.domain.util.log
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.io.IOException
+import javax.inject.Inject
+
+class DoKakaoLogin @Inject constructor(
+    private val repository: UserRepository
+) {
+    operator fun invoke(token: String): Flow<Resource<IdentificationDTO>> = flow {
+        try {
+            emit(Resource.Loading())
+            val r = repository.doKakaoLogin(token)
+            when(r.code()) {
+                200 -> {
+                    emit(Resource.Success(r.body()!!))
+                }
+                else -> {
+                    "use case ERROR ${r.code()}: ${r.errorBody().toString()}".log()
+                }
+            }
+
+        } catch(e: IOException) {
+            emit(Resource.Error("Couldn't reach server. Check your internet connection."))
+        }
+    }
+}

--- a/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/Login/LoginUseCases.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/Login/LoginUseCases.kt
@@ -4,6 +4,7 @@ import javax.inject.Inject
 
 data class LoginUseCases @Inject constructor(
     val doLogin: DoLogin,
+    val doKakaoLogin: DoKakaoLogin,
     val getToken: GetToken,
     val getUserID: GetUserID,
     val getFCMToken: GetFCMToken,

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/KakaoLoginViewModel.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/KakaoLoginViewModel.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.d_vide.D_VIDE.app.data.remote.responseDTO.IdentificationDTO
-import com.d_vide.D_VIDE.app.domain.use_case.Login.DoKakaoLogin
 import com.d_vide.D_VIDE.app.domain.use_case.Login.LoginUseCases
 import com.d_vide.D_VIDE.app.domain.util.Resource
 import com.d_vide.D_VIDE.app.domain.util.log
@@ -23,9 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class KakaoLoginViewModel @Inject constructor(
     private val loginUseCases: LoginUseCases,
-    @ApplicationContext context: Context,
-) : ViewModel() {
-    private val context = context
+): ViewModel() {
     private val _eventFlow = MutableSharedFlow<UiEvent>()
     private var identification = mutableStateOf(IdentificationDTO())
     val eventFlow = _eventFlow.asSharedFlow()
@@ -70,7 +67,7 @@ class KakaoLoginViewModel @Inject constructor(
         return !identification.value.token.isNullOrBlank()
     }
 
-    fun handleKakaoLogin() {
+    fun handleKakaoLogin(context: Context) {
         // 카카오계정으로 로그인 공통 callback 구성
         // 카카오톡으로 로그인 할 수 없어 카카오계정으로 로그인할 경우 사용됨
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
@@ -86,7 +83,7 @@ class KakaoLoginViewModel @Inject constructor(
         if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
             UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
                 if (error != null) {
-                    "카카오톡으로 로그인 실패".log()
+                    "카카오톡으로 로그인 실패 $error".log()
 
                     // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
                     // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
@@ -112,7 +109,7 @@ class KakaoLoginViewModel @Inject constructor(
             is LoginEvent.LoginByKakao -> {
                 viewModelScope.launch {
                     try {
-                        handleKakaoLogin()
+                        handleKakaoLogin(event.context)
                     } catch (e: Exception) {
                         "로그인 중 에러 발생".log()
                         _eventFlow.emit(UiEvent.ERROR(message = "로그인 중 에러 발생"))

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/KakaoLoginViewModel.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/KakaoLoginViewModel.kt
@@ -1,0 +1,53 @@
+package com.d_vide.D_VIDE.app.presentation.Login
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import com.d_vide.D_VIDE.app.domain.util.log
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+@HiltViewModel
+class KakaoLoginViewModel @Inject constructor(
+    @ApplicationContext context: Context
+) : ViewModel() {
+    private val context = context
+
+    fun handleKakaoLogin() {
+        // 카카오계정으로 로그인 공통 callback 구성
+        // 카카오톡으로 로그인 할 수 없어 카카오계정으로 로그인할 경우 사용됨
+        val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+            if (error != null) {
+                "카카오계정으로 로그인 실패".log()
+            } else if (token != null) {
+                "카카오계정으로 로그인 성공 ${token.accessToken}".log()
+            }
+        }
+
+        // 카카오톡이 설치되어 있으면 카카오톡으로 로그인, 아니면 카카오계정으로 로그인
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                if (error != null) {
+                    "카카오톡으로 로그인 실패".log()
+
+                    // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
+                    // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
+                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                        return@loginWithKakaoTalk
+                    }
+
+                    // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
+                    UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+                } else if (token != null) {
+                    "카카오톡으로 로그인 성공 ${token.accessToken}".log()
+                }
+            }
+        } else {
+            UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+        }
+    }
+}

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/LoginEvent.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/LoginEvent.kt
@@ -5,6 +5,6 @@ import com.d_vide.D_VIDE.app._enums.Category
 sealed class LoginEvent {
     data class EnteredEmail(val value: String): LoginEvent()
     data class EnteredPassword(val value: String): LoginEvent()
-
+    object LoginByKakao: LoginEvent()
     object Login: LoginEvent()
 }

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/LoginEvent.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/LoginEvent.kt
@@ -1,10 +1,11 @@
 package com.d_vide.D_VIDE.app.presentation.Login
 
+import android.content.Context
 import com.d_vide.D_VIDE.app._enums.Category
 
 sealed class LoginEvent {
     data class EnteredEmail(val value: String): LoginEvent()
     data class EnteredPassword(val value: String): LoginEvent()
-    object LoginByKakao: LoginEvent()
+    data class LoginByKakao(val context: Context): LoginEvent()
     object Login: LoginEvent()
 }

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/SocialLoginScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/SocialLoginScreen.kt
@@ -1,6 +1,5 @@
 package com.d_vide.D_VIDE.app.presentation.Login
 
-import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
@@ -8,16 +7,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Alignment.Companion.Bottom
-import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterStart
 import androidx.compose.ui.Alignment.Companion.End
-import androidx.compose.ui.Alignment.Companion.Start
-import androidx.compose.ui.Alignment.Companion.TopStart
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.Black
 import androidx.compose.ui.graphics.Color.Companion.White
@@ -25,57 +19,63 @@ import androidx.compose.ui.res.painterResource
 import com.d_vide.D_VIDE.R
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.d_vide.D_VIDE.ui.theme.*
 
 @Composable
-fun SocialLoginScreen (
-    navController: NavController
-){
+fun SocialLoginScreen(
+    navController: NavController,
+    kakaoViewModel: KakaoLoginViewModel = hiltViewModel(),
+) {
     val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(White)
-    ){
-       Column(
-           modifier = Modifier
-               .padding(top = 47.dp, start = 39.dp, end = 31.dp)
-               .verticalScroll(scrollState)
-       ){
-           LoginImage()
-           LoginButton(
-               onClick = {/*do somehting*/},
-               text = "카카오 로그인",
-               resId = R.drawable.kakao_logo,
-               color = Color(0xFFFEE500),
-               textColor = Black
-           )
-           Spacer(modifier = Modifier.height(12.dp))
-           LoginButton(
-               onClick = {/*do somehting*/},
-               text = "애플로 로그인",
-               resId = R.drawable.apple_logo,
-               color = Black,
-               textColor = White
-           )
-           Spacer(modifier = Modifier.height(28.dp))
-           Text(
-               modifier = Modifier
-                   .align(CenterHorizontally)
-                   .padding(bottom = 3.dp),
-               text = "고객센터 문의하기",
-               style = TextStyles.Small2,
-               color = gray2,
-           )
-           Divider(modifier = Modifier
-               .size(110.dp, 1.dp)
-               .align(CenterHorizontally),  color = gray4)
-           Spacer(modifier = Modifier.height(32.dp))
-       }
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(top = 47.dp, start = 39.dp, end = 31.dp)
+                .verticalScroll(scrollState)
+        ) {
+            LoginImage()
+            LoginButton(
+                onClick = { kakaoViewModel.handleKakaoLogin() },
+                text = "카카오 로그인",
+                resId = R.drawable.kakao_logo,
+                color = Color(0xFFFEE500),
+                textColor = Black
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            LoginButton(
+                onClick = {/*do somehting*/ },
+                text = "애플로 로그인",
+                resId = R.drawable.apple_logo,
+                color = Black,
+                textColor = White
+            )
+            Spacer(modifier = Modifier.height(28.dp))
+            Text(
+                modifier = Modifier
+                    .align(CenterHorizontally)
+                    .padding(bottom = 3.dp),
+                text = "고객센터 문의하기",
+                style = TextStyles.Small2,
+                color = gray2,
+            )
+            Divider(
+                modifier = Modifier
+                    .size(110.dp, 1.dp)
+                    .align(CenterHorizontally), color = gray4
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+        }
         Image(
-            modifier = Modifier.height(109.5.dp).fillMaxWidth(),
+            modifier = Modifier
+                .height(109.5.dp)
+                .fillMaxWidth(),
             painter = painterResource(id = R.drawable.login_dividers),
             contentDescription = "login_dividers"
         )
@@ -83,7 +83,7 @@ fun SocialLoginScreen (
 }
 
 @Composable
-fun LoginImage(){
+fun LoginImage() {
     Column {
         Divider(
             modifier = Modifier
@@ -119,6 +119,7 @@ fun LoginImage(){
         )
     }
 }
+
 @Composable
 fun LoginButton(
     onClick: () -> Unit = {},
@@ -126,12 +127,14 @@ fun LoginButton(
     textColor: Color = Color(0xFFFFFFFF),
     color: Color = Color(0xFFFFFFFF),
     @DrawableRes resId: Int
-){
+) {
     Button(
         onClick = onClick,
         colors = ButtonDefaults.buttonColors(backgroundColor = color),
         shape = RoundedCornerShape(26.dp),
-        modifier = Modifier.height(45.dp).fillMaxWidth(),
+        modifier = Modifier
+            .height(45.dp)
+            .fillMaxWidth(),
         contentPadding = PaddingValues(0.dp)
     ) {
         Box(
@@ -140,7 +143,7 @@ fun LoginButton(
                 .padding(end = 7.dp)
                 .fillMaxWidth()
                 .background(color)
-        ){
+        ) {
             Image(
                 modifier = Modifier
                     .padding(start = 16.dp)
@@ -158,8 +161,11 @@ fun LoginButton(
         }
     }
 }
+
 @Preview
 @Composable
 fun PreviewSocialLoginScreen() {
-    SocialLoginScreen(rememberNavController())
+    DVIDETheme {
+        SocialLoginScreen(rememberNavController())
+    }
 }

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/SocialLoginScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/SocialLoginScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
@@ -22,13 +23,30 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.d_vide.D_VIDE.app.domain.util.log
+import com.d_vide.D_VIDE.app.presentation.navigation.Screen
 import com.d_vide.D_VIDE.ui.theme.*
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun SocialLoginScreen(
     navController: NavController,
     kakaoViewModel: KakaoLoginViewModel = hiltViewModel(),
 ) {
+    LaunchedEffect(key1 = true) {
+        kakaoViewModel.eventFlow.collectLatest { event ->
+            when(event) {
+                is KakaoLoginViewModel.UiEvent.ERROR -> {
+                    "LOGIN ERROR!!".log()
+                }
+                is KakaoLoginViewModel.UiEvent.Login -> {
+                    "LOGIN SUCCESS!!".log()
+                    navController.navigate(Screen.HomeScreen.route)
+                }
+            }
+        }
+    }
+
     val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
@@ -42,7 +60,7 @@ fun SocialLoginScreen(
         ) {
             LoginImage()
             LoginButton(
-                onClick = { kakaoViewModel.handleKakaoLogin() },
+                onClick = { kakaoViewModel.onEvent(LoginEvent.LoginByKakao) },
                 text = "카카오 로그인",
                 resId = R.drawable.kakao_logo,
                 color = Color(0xFFFEE500),

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/SocialLoginScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/Login/SocialLoginScreen.kt
@@ -1,5 +1,6 @@
 package com.d_vide.D_VIDE.app.presentation.Login
 
+import android.app.Activity
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
@@ -16,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Color.Companion.Black
 import androidx.compose.ui.graphics.Color.Companion.White
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import com.d_vide.D_VIDE.R
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,6 +55,7 @@ fun SocialLoginScreen(
             .fillMaxSize()
             .background(White)
     ) {
+        val context = LocalContext.current as Activity
         Column(
             modifier = Modifier
                 .padding(top = 47.dp, start = 39.dp, end = 31.dp)
@@ -60,7 +63,7 @@ fun SocialLoginScreen(
         ) {
             LoginImage()
             LoginButton(
-                onClick = { kakaoViewModel.onEvent(LoginEvent.LoginByKakao) },
+                onClick = { kakaoViewModel.onEvent(LoginEvent.LoginByKakao(context)) },
                 text = "카카오 로그인",
                 resId = R.drawable.kakao_logo,
                 color = Color(0xFFFEE500),

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/SplashScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/SplashScreen.kt
@@ -27,9 +27,9 @@ import kotlinx.coroutines.delay
 
 @Composable
 fun SplashScreen(
-    navController: NavController
+    navController: NavController,
+    loginViewModel: KakaoLoginViewModel = hiltViewModel()
 ) {
-    val loginViewModel = hiltViewModel<KakaoLoginViewModel>()
     var startAnimation by remember { mutableStateOf(false) }
     val alphaAnim = animateFloatAsState(
         targetValue = if (startAnimation) 1f else 0f,

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/SplashScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/SplashScreen.kt
@@ -37,8 +37,10 @@ fun SplashScreen(
 
     LaunchedEffect(key1 = true) {
         val nextScreen = when (loginViewModel.isLoggedIn()) {
-            true -> Screen.HomeScreen
-            false -> Screen.LoginScreen
+//            true -> Screen.HomeScreen
+//            false -> Screen.LoginScreen
+            true -> Screen.SocialLoginScreen
+            false -> Screen.SocialLoginScreen
         }
         startAnimation = true
 

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/SplashScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/SplashScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.d_vide.D_VIDE.app._constants.Const.UIConst.DURATION_ANIMATION_SPLASH
+import com.d_vide.D_VIDE.app.presentation.Login.KakaoLoginViewModel
 import com.d_vide.D_VIDE.app.presentation.Login.LoginViewModel
 import com.d_vide.D_VIDE.app.presentation.navigation.Screen
 import com.d_vide.D_VIDE.ui.theme.TextStyles.Big1
@@ -28,7 +29,7 @@ import kotlinx.coroutines.delay
 fun SplashScreen(
     navController: NavController
 ) {
-    val loginViewModel = hiltViewModel<LoginViewModel>()
+    val loginViewModel = hiltViewModel<KakaoLoginViewModel>()
     var startAnimation by remember { mutableStateOf(false) }
     val alphaAnim = animateFloatAsState(
         targetValue = if (startAnimation) 1f else 0f,
@@ -37,9 +38,7 @@ fun SplashScreen(
 
     LaunchedEffect(key1 = true) {
         val nextScreen = when (loginViewModel.isLoggedIn()) {
-//            true -> Screen.HomeScreen
-//            false -> Screen.LoginScreen
-            true -> Screen.SocialLoginScreen
+            true -> Screen.HomeScreen
             false -> Screen.SocialLoginScreen
         }
         startAnimation = true

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/navigation/NavGraph.kt
@@ -9,6 +9,7 @@ import com.d_vide.D_VIDE.app.presentation.Followings.OtherFollowScreen
 import com.d_vide.D_VIDE.app.presentation.Followings.MyFollowScreen
 import com.d_vide.D_VIDE.app.presentation.MyPage.MyPageScreen
 import com.d_vide.D_VIDE.app.presentation.Login.LoginScreen
+import com.d_vide.D_VIDE.app.presentation.Login.SocialLoginScreen
 import com.d_vide.D_VIDE.app.presentation.MyOrders.MyOrdersScreen
 import com.d_vide.D_VIDE.app.presentation.MyReviews.MyReviewsScreen
 import com.d_vide.D_VIDE.app.presentation.PostRecruiting.PostRecruitingScreen
@@ -55,6 +56,13 @@ fun NavGraphBuilder.divideGraph(
     ) {
         LoginScreen(navController)
     }
+
+    composable(
+        route = Screen.SocialLoginScreen.route
+    ) {
+        SocialLoginScreen(navController)
+    }
+
 
     composable(
         "${Screen.ReviewDetailScreen.route}/{${DetailDestinationKey.REVIEW}}",

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/navigation/NavGraph.kt
@@ -20,7 +20,6 @@ import com.d_vide.D_VIDE.app.presentation.ReviewDetail.ReviewDetail
 import com.d_vide.D_VIDE.app.presentation.Reviews.Reviews
 import com.d_vide.D_VIDE.app.presentation.SplashScreen
 import com.d_vide.D_VIDE.app.presentation.TaggedReviews.TaggedReviewsScreen
-import com.d_vide.D_VIDE.app.presentation.UserFeed.UserFeedScreen
 
 
 fun NavGraphBuilder.divideGraph(

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/navigation/Screen.kt
@@ -40,5 +40,6 @@ val shouldNotShowBottomScreen = listOf(
     Screen.PostRecruitingScreen.route,
     Screen.SplashScreen.route,
     Screen.LoginScreen.route,
+    Screen.SocialLoginScreen.route,
     Screen.ChattingDetailScreen.route+"/{${DetailDestinationKey.CHATTING}}"
 )

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/navigation/Screen.kt
@@ -3,6 +3,7 @@ package com.d_vide.D_VIDE.app.presentation.navigation
 sealed class Screen(val route: String) {
     object SplashScreen: Screen("splash_screen")
     object LoginScreen: Screen("login_screen")
+    object SocialLoginScreen: Screen("social_login_screen")
     object HomeScreen: Screen("home_screen")
     object RecruitingsScreen: Screen("recruitings_screen")
     object PostRecruitingScreen: Screen("post_recruiting_screen")

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,13 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/'}
     }
     dependencies {
         classpath "com.android.tools.build:gradle-api:7.0.4"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,9 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://devrepo.kakao.com/nexus/content/groups/public/' }
     }
 }
+
 rootProject.name = "D-VIDE"
 include ':app'


### PR DESCRIPTION
close #111 

- 서버와 연결에 카카오 소셜로그인을 구현했습니다.
- 기존 로그인 화면이 소셜로그인 화면으로 대체되었습니다.
- 카카오 로그인 시 닉네임/ 프로필이미지/ 이메일 등이 설정됩니다.
- gradle 설정이 변경되었습니다.
- NATIVE_KAKAO_APPKEY 를 local.properties에 추가해야합니다. 키값은 [여기](https://developers.kakao.com/console/app/823505)서 확인
