### PR TITLE
112 [Refactoring] DataStore의 get/set usecase 들의 layering

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,6 +152,9 @@ dependencies {
 //    implementation "com.kakao.sdk:v2-share:2.11.2" // 메시지(카카오톡 공유)
 //    implementation "com.kakao.sdk:v2-navi:2.11.2" // 카카오내비
 //    implementation "com.kakao.sdk:v2-friend:2.11.2" // 카카오톡 소셜 피커, 리소스 번들 파일 포함
+
+    // serialization
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
 }
 
 kapt {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'dagger.hilt.android.plugin'
     id 'com.google.gms.google-services'
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
+    id 'kotlinx-serialization'
 }
 
 android {

--- a/app/src/main/java/com/d_vide/D_VIDE/app/data/remote/responseDTO/BadgeDTO.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/data/remote/responseDTO/BadgeDTO.kt
@@ -1,5 +1,8 @@
 package com.d_vide.D_VIDE.app.data.remote.responseDTO
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class BadgeDTO(
     val name: String = "",
     val description: String = ""

--- a/app/src/main/java/com/d_vide/D_VIDE/app/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/data/repository/UserRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.d_vide.D_VIDE.app.data.remote.requestDTO.FcmTokenDTO
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.UserIdDTO
 import com.d_vide.D_VIDE.app.data.remote.responseDTO.*
 import com.d_vide.D_VIDE.app.data.storage.UserStore
+import com.d_vide.D_VIDE.app.domain.model.UserInfo
 import com.d_vide.D_VIDE.app.domain.repository.UserRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -15,7 +16,6 @@ import kotlinx.coroutines.runBlocking
 import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlinx.coroutines.flow.first
 
 @Singleton
 class UserRepositoryImpl @Inject constructor(
@@ -30,7 +30,7 @@ class UserRepositoryImpl @Inject constructor(
         return api.kakaoLogin(AccessToken(token))
     }
 
-    override suspend fun getUserInfo(): Response<UserDTO> {
+    override suspend fun getUser(): Response<UserDTO> {
         return api.getUserInfo()
     }
 
@@ -55,6 +55,18 @@ class UserRepositoryImpl @Inject constructor(
     override fun setUserID(ID: Long) {
         runBlocking(Dispatchers.IO) {
             store.setUserID(ID)
+        }
+    }
+
+    override fun getUserInfo(): UserInfo {
+        return runBlocking(Dispatchers.IO) {
+            store.getUserInfo().first()
+        }
+    }
+
+    override fun setUserInfo(userInfo: UserInfo) {
+        runBlocking(Dispatchers.IO) {
+            store.setUserInfo(userInfo)
         }
     }
 

--- a/app/src/main/java/com/d_vide/D_VIDE/app/data/storage/UserStore.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/data/storage/UserStore.kt
@@ -4,9 +4,14 @@ import android.content.Context
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.d_vide.D_VIDE.app.data.remote.responseDTO.BadgeDTO
+import com.d_vide.D_VIDE.app.domain.model.UserInfo
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 val Context.dataStore by preferencesDataStore("user")
@@ -14,45 +19,44 @@ val Context.dataStore by preferencesDataStore("user")
 class UserStore @Inject constructor(@ApplicationContext context: Context) {
     private val store = context.dataStore
 
-    suspend fun setToken(token: String) {
-        store.edit {
-            it[USER_TOKEN] = token
-        }
-    }
+    suspend fun setUserInfo(userInfo: UserInfo) { store.edit { it[USER_INFO] = Json.encodeToString(userInfo) } }
+    suspend fun setUserID(id: Long) { store.edit { it[USER_INFO] = id.toString() } }
+//    suspend fun setUserEmail(email: String) { store.edit { it[USER_EMAIL] = email } }
+//    suspend fun setUserNickname(email: String) { store.edit { it[USER_NICKNAME] = email } }
+//    suspend fun setUserProfileImg(profileImg_url: String) { store.edit { it[USER_PRF] = profileImg_url } }
+//    suspend fun setUserBadge(badge: BadgeDTO) { store.edit { it[USER_BADGE] = Json.encodeToString(badge) } }
+//    suspend fun setUserFollowerCount(followerCount: Int) { store.edit { it[USER_FLR] = followerCount.toString() } }
+//    suspend fun setUserFollowingCount(followingCount: Int) { store.edit { it[USER_FLG] = followingCount.toString() } }
+//    suspend fun setUserCarbonAmount(amount: Int) { store.edit { it[USER_CARBON] = amount.toString() } }
+//    suspend fun setUserSavedPrice(saved_price: Int) { store.edit { it[USER_SAVED_PRICE] = saved_price.toString() } }
+    suspend fun setToken(token: String) { store.edit { it[USER_TOKEN] = token } }
+    suspend fun setFCMToken(token: String) { store.edit { it[FCM_TOKEN] = token } }
 
-    suspend fun setUserID(ID: Long) {
-        store.edit {
-            it[USER_ID] = ID.toString()
-        }
-    }
-
-    suspend fun setFCMToken(token: String) {
-        store.edit {
-            it[FCM_TOKEN] = token
-        }
-    }
-
-    fun getToken(): Flow<String> {
-        return store.data.map {
-            it[USER_TOKEN]!!
-        }
-    }
-
-    fun getUserID(): Flow<Long> {
-        return store.data.map {
-            (it[USER_ID]!!).toLong()
-        }
-    }
-
-    fun getFCMToken(): Flow<String> {
-        return store.data.map {
-            it[FCM_TOKEN]!!
-        }
-    }
+    fun getUserInfo(): Flow<UserInfo> { return store.data.map { Json.decodeFromString(it[USER_INFO]!!) } }
+    fun getUserID(): Flow<Long> { return store.data.map { (it[USER_ID]!!).toLong() } }
+//    fun getUserEmail(): Flow<String> { return store.data.map { it[USER_EMAIL]!! } }
+//    fun getUserNickname(): Flow<String> { return store.data.map { it[USER_NICKNAME]!! } }
+//    fun getUserProfileImg(): Flow<String> { return store.data.map { it[USER_PRF]!! } }
+//    fun getUserBadge(): Flow<BadgeDTO> { return store.data.map { Json.decodeFromString(it[USER_BADGE]!!) } }
+//    fun setUserFollowerCount(): Flow<Int> { return store.data.map { (it[USER_FLR]!!).toInt() } }
+//    fun setUserFollowingCount(): Flow<Int> { return store.data.map { (it[USER_FLG]!!).toInt() } }
+//    fun setUserCarbonAmount(): Flow<Int> { return store.data.map { (it[USER_CARBON]!!).toInt() } }
+//    fun setUserSavedPrice(): Flow<Int> { return store.data.map { (it[USER_SAVED_PRICE]!!).toInt() } }
+    fun getToken(): Flow<String> { return store.data.map { it[USER_TOKEN]!! } }
+    fun getFCMToken(): Flow<String> { return store.data.map { it[FCM_TOKEN]!! } }
 
     companion object {
-        private val USER_TOKEN = stringPreferencesKey("token")
+        private val USER_INFO = stringPreferencesKey("user_info")
         private val USER_ID = stringPreferencesKey("id")
+        private val USER_EMAIL = stringPreferencesKey("token")
+        private val USER_NICKNAME = stringPreferencesKey("nickname")
+        private val USER_BADGE = stringPreferencesKey("badge")
+        private val USER_PRF = stringPreferencesKey("profile")
+        private val USER_FLR = stringPreferencesKey("follower")
+        private val USER_FLG = stringPreferencesKey("following")
+        private val USER_CARBON = stringPreferencesKey("carbon")
+        private val USER_SAVED_PRICE = stringPreferencesKey("saved_price")
+        private val USER_TOKEN = stringPreferencesKey("token")
         private val FCM_TOKEN = stringPreferencesKey("fcm")
     }
 }

--- a/app/src/main/java/com/d_vide/D_VIDE/app/domain/model/UserInfo.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/domain/model/UserInfo.kt
@@ -1,0 +1,28 @@
+package com.d_vide.D_VIDE.app.domain.model
+
+import com.d_vide.D_VIDE.app.data.remote.responseDTO.BadgeDTO
+import com.d_vide.D_VIDE.app.data.remote.responseDTO.UserDTO
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserInfo(
+    var userId: Long = 0L,
+    var email: String = "",
+    var nickname: String = "",
+    var badge: BadgeDTO = BadgeDTO(),
+    var profileImgUrl: String = "",
+    var followerCount: Int = 0,
+    var followingCount: Int = 0,
+    val carbonAmount: Int = 0,
+    var savedPrice: Int = 0,
+) {
+    fun setByUser(user: UserDTO) {
+        email = user.email
+        nickname = user.nickname
+        profileImgUrl = user.profileImgUrl
+        badge = user.badge
+        followerCount = user.followerCount
+        followingCount = user.followingCount
+        savedPrice = user.savedPrice
+    }
+}

--- a/app/src/main/java/com/d_vide/D_VIDE/app/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/domain/repository/UserRepository.kt
@@ -5,6 +5,7 @@ import com.d_vide.D_VIDE.app.data.remote.requestDTO.EmailPasswordDTO
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.FcmTokenDTO
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.UserIdDTO
 import com.d_vide.D_VIDE.app.data.remote.responseDTO.*
+import com.d_vide.D_VIDE.app.domain.model.UserInfo
 import retrofit2.Response
 
 interface UserRepository {
@@ -12,13 +13,16 @@ interface UserRepository {
     suspend fun doLogin(emailPw: EmailPasswordDTO): Response<IdentificationDTO>
     suspend fun doKakaoLogin(token: String): Response<IdentificationDTO>
 
-    suspend fun getUserInfo(): Response<UserDTO>
+    suspend fun getUser(): Response<UserDTO>
 
     fun getUserToken(): String
     fun setUserToken(token: String)
 
     fun getUserID(): Long
     fun setUserID(ID: Long)
+
+    fun getUserInfo(): UserInfo
+    fun setUserInfo(userInfo: UserInfo)
 
     fun getFCMToken(): String
     fun setFCMToken(token: String)

--- a/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/Follow/PostFollow.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/Follow/PostFollow.kt
@@ -5,6 +5,7 @@ import com.d_vide.D_VIDE.app.data.remote.responseDTO.FollowIdDTO
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.UserIdDTO
 import com.d_vide.D_VIDE.app.domain.repository.UserRepository
 import com.d_vide.D_VIDE.app.domain.util.Resource
+import com.d_vide.D_VIDE.app.presentation.state.UserInformation.userInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import retrofit2.HttpException
@@ -22,6 +23,8 @@ class PostFollow @Inject constructor(
             when(r.code()) {
                 201 -> {
                     Log.d("test", r.body()!!.toString())
+                    userInfo.followingCount++
+                    repository.setUserInfo(userInfo)
                     emit(Resource.Success(r.body()!!))
                 }
                 else -> {

--- a/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/Login/DoKakaoLogin.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/Login/DoKakaoLogin.kt
@@ -5,14 +5,18 @@ import com.d_vide.D_VIDE.app.data.storage.UserStore
 import com.d_vide.D_VIDE.app.domain.repository.UserRepository
 import com.d_vide.D_VIDE.app.domain.util.Resource
 import com.d_vide.D_VIDE.app.domain.util.log
+import com.d_vide.D_VIDE.app.presentation.state.UserInformation
+import com.d_vide.D_VIDE.app.presentation.state.UserInformation.userInfo
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import java.io.IOException
 import javax.inject.Inject
 
 class DoKakaoLogin @Inject constructor(
     private val repository: UserRepository,
-    private val datastore: UserStore
 ) {
     operator fun invoke(token: String): Flow<Resource<IdentificationDTO>> = flow {
         try {
@@ -21,8 +25,10 @@ class DoKakaoLogin @Inject constructor(
             when(r.code()) {
                 200 -> {
                     emit(Resource.Success(r.body()!!))
-                    datastore.setToken(r.body()!!.token)
-                    datastore.setUserID(r.body()!!.userId)
+                    repository.setUserToken(r.body()!!.token)
+                    repository.setUserID(r.body()!!.userId)
+                    userInfo.userId = r.body()!!.userId
+                    repository.setUserInfo(userInfo)
                 }
                 else -> {
                     "use case ERROR ${r.code()}: ${r.errorBody().toString()}".log()

--- a/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/User/GetUserInfo.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/domain/use_case/User/GetUserInfo.kt
@@ -1,9 +1,11 @@
 package com.d_vide.D_VIDE.app.domain.use_case.User
 
 import com.d_vide.D_VIDE.app.data.remote.responseDTO.UserDTO
+import com.d_vide.D_VIDE.app.data.storage.UserStore
 import com.d_vide.D_VIDE.app.domain.repository.UserRepository
 import com.d_vide.D_VIDE.app.domain.util.Resource
 import com.d_vide.D_VIDE.app.domain.util.log
+import com.d_vide.D_VIDE.app.presentation.state.UserInformation.userInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import retrofit2.HttpException
@@ -12,16 +14,21 @@ import javax.inject.Inject
 
 class GetUserInfo @Inject constructor(
     private val repository: UserRepository,
+    private val dataStore: UserStore,
 ) {
     operator fun invoke(): Flow<Resource<UserDTO>> = flow {
 
         try {
             emit(Resource.Loading())
-            val r = repository.getUserInfo()
+            val r = repository.getUser()
             when(r.code()) {
-                200 -> { emit(Resource.Success(r.body()!!)) }
+                200 -> {
+                    emit(Resource.Success(r.body()!!))
+                    userInfo.setByUser(r.body()!!)
+                    dataStore.setUserInfo(userInfo)
+                }
                 else -> {
-                    "usecase ERROR ${r.code()}: ${r.errorBody().toString()}".log()
+                    "use case ERROR ${r.code()}: ${r.errorBody().toString()}".log()
                 }
             }
 

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/state/UserInformation.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/state/UserInformation.kt
@@ -1,15 +1,14 @@
 package com.d_vide.D_VIDE.app.presentation.state
 
+import com.d_vide.D_VIDE.app.domain.model.UserInfo
 import com.d_vide.D_VIDE.app.domain.util.log
 
 object UserInformation {
-    var userId: Long = 0
-    var email : String = ""
-    var profileImg_url: String = ""
+    var userInfo: UserInfo = UserInfo()
     var token: String = ""
     var fcm: String = ""
 
     fun logUser() {
-        "[USER] : ID:$userId/EMAIL:$email/JWT:$token/FCM:$fcm".log()
+        "[USER] : ID:${userInfo.userId}/EMAIL:$userInfo.email/NICK:${userInfo.nickname}/FOLLOW:${userInfo.followerCount},${userInfo.followingCount}/JWT:$token/FCM:$fcm".log()
     }
 }

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/Followings/MyFollowScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/Followings/MyFollowScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.d_vide.D_VIDE.app.domain.util.log
 import com.d_vide.D_VIDE.app.presentation.view.UserFeed.BottomSheetUserFeedScreen
 import com.d_vide.D_VIDE.app.presentation.view.UserFeed.UserProfileViewModel
 import com.d_vide.D_VIDE.app.presentation.util.GradientComponent
@@ -28,17 +29,17 @@ fun MyFollowScreen(
     upPress: () -> Unit = {},
     onReviewSelected: (Int) -> Unit,
     onTagClick: (String) -> Unit,
-    isFollowing: Boolean = false
+    isFollowing: Boolean = false,
+    followViewModel: FollowViewModel = hiltViewModel(),
 ) {
-    val viewModel = hiltViewModel<FollowViewModel>()
-    val follows = viewModel.state.value.follows
     val userViewModel = hiltViewModel<UserProfileViewModel>()
-    val coroutine = rememberCoroutineScope()
     val userId = rememberSaveable{ mutableStateOf(0L) }
 
-    coroutine.launch {
-        viewModel.getFollowInfo(relation = if(isFollowing) "FOLLOWING" else "FOLLOWER")
+    LaunchedEffect(key1 = true) {
+        val relation = if(isFollowing) "FOLLOWING" else "FOLLOWER"
+        followViewModel.getFollowInfo(relation, 0)
     }
+
     BottomSheetUserFeedScreen(
         navController = navController,
         onReviewSelected = onReviewSelected,
@@ -56,7 +57,7 @@ fun MyFollowScreen(
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                     contentPadding = PaddingValues(top = 16.dp)
                 ) {
-                    follows.forEach { item ->
+                    followViewModel.state.value.follows.forEach { item ->
                         item {
                             FollowingItem(
                                 userName = item.nickname,
@@ -64,8 +65,8 @@ fun MyFollowScreen(
                                 modifier = Modifier.padding(start = 33.dp, end = 40.dp),
                                 onUserClick = {
                                     userId.value = item.userId
+                                    userViewModel.getOtherUserInfo(item.userId)
                                     scope.launch {
-                                        userViewModel.getOtherUserInfo(item.userId)
                                         state.animateTo(
                                             ModalBottomSheetValue.Expanded,
                                             tween(500)

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/Login/KakaoLoginViewModel.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/Login/KakaoLoginViewModel.kt
@@ -37,7 +37,7 @@ class KakaoLoginViewModel @Inject constructor(
     }
 
     private suspend fun loginWithKakao(token: String) {
-        loginUseCases.doKakaoLogin(token).collect() { it ->
+        loginUseCases.doKakaoLogin(token).collect() {
             when (it) {
                 is Resource.Success -> {
                     "userID: ${it.data!!.userId}, token: ${it.data!!.token}".log()
@@ -112,6 +112,7 @@ class KakaoLoginViewModel @Inject constructor(
                     }
                 }
             }
+            else -> {}
         }
     }
 

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/MyPage/MyPageScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/MyPage/MyPageScreen.kt
@@ -46,6 +46,7 @@ import com.d_vide.D_VIDE.app.domain.util.log
 import com.d_vide.D_VIDE.app.presentation.navigation.NavGraph
 import com.d_vide.D_VIDE.app.presentation.navigation.Screen
 import com.d_vide.D_VIDE.app.presentation.util.formatAmountOrMessage
+import com.d_vide.D_VIDE.app.presentation.view.Followings.FollowViewModel
 import com.d_vide.D_VIDE.ui.theme.*
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
@@ -54,9 +55,8 @@ import com.google.accompanist.pager.rememberPagerState
 @Composable
 fun MyPageScreen(
     navController: NavController,
-    viewModel: MyPageViewModel = hiltViewModel()
+    viewModel: MyPageViewModel = hiltViewModel(),
 ) {
-    val viewModelState = viewModel.state.userDTO
     val scrollState = rememberScrollState()
 
     Box(modifier = Modifier.background(background)) {
@@ -65,29 +65,32 @@ fun MyPageScreen(
                 .fillMaxSize()
                 .padding(20.dp)
                 .zIndex(2F)
-                .verticalScroll(scrollState)
-            ,
+                .verticalScroll(scrollState),
             verticalArrangement = Arrangement.spacedBy(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             MyPageUserProfile(
-                username = viewModelState.nickname ?: "알 수 없는 사용자",
-                badges = viewModel.badge ?: "알 수 없는 사용자",
-                followerCount = viewModelState.followerCount ?: 0,
-                followingCount = viewModelState.followingCount ?: 0,
-                image = viewModelState.profileImgUrl ?: "",
-                onFollowerClick = { navController.navigate("${Screen.MyFollowScreen.route}/false") },
-                onFollowingClick = { navController.navigate("${Screen.MyFollowScreen.route}/true")},
-                allBadges = viewModel.state.badgesDTO ?: emptyList(),
+                username = viewModel.user.nickname,
+                badges = viewModel.user.badge.name,
+                followerCount = viewModel.user.followerCount,
+                followingCount = viewModel.user.followingCount,
+                image = viewModel.user.profileImgUrl,
+                onFollowerClick = {
+                    navController.navigate("${Screen.MyFollowScreen.route}/false")
+                },
+                onFollowingClick = {
+                    navController.navigate("${Screen.MyFollowScreen.route}/true")
+                },
+                allBadges = viewModel.state.badgesDTO,
             )
-            MyPageSavings(viewModelState.savedPrice ?: 0)
+            MyPageSavings(viewModel.user.savedPrice)
             MyPageCommonCell("나의 주문내역 보기") {
                 navController.navigate(NavGraph.MYREVIEW)
             }
-            MyPageCommonCell("내가 쓴 리뷰 보기"){
+            MyPageCommonCell("내가 쓴 리뷰 보기") {
                 navController.navigate(Screen.MyReviewsScreen.route)
             }
-            MyPageCommonCell("고객센터로 이동 "){
+            MyPageCommonCell("고객센터로 이동 ") {
                 navController.navigate(Screen.PostReviewScreen.route)
             }
         }
@@ -108,21 +111,21 @@ fun BackgroundImage(
             .size(200.dp)
             .zIndex(1F)
             .clipToBounds()
-            .offset(x = (90).dp)
-        ,
+            .offset(x = (90).dp),
         alpha = 0.2F
     )
 }
 
 @Composable
 fun MyPageCommonCell(
-    text : String,
-    onClick : () -> Unit = {}
+    text: String,
+    onClick: () -> Unit = {}
 ) {
     CardContainer(onClick = onClick) {
-        Box(modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp)
         ) {
             Text(
                 text = text,
@@ -154,7 +157,7 @@ fun MyPageSavings(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text("절약한 탄소배출", fontSize = 12.sp)
-            Divider(modifier = Modifier.size(0.dp, 12.dp), )
+            Divider(modifier = Modifier.size(0.dp, 12.dp))
             Text("절약한 배달비", fontSize = 12.sp)
         }
         Spacer(modifier = Modifier.size(15.dp))
@@ -165,12 +168,22 @@ fun MyPageSavings(
             horizontalArrangement = SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(formatAmountOrMessage(savedPrice.toString())+" 원", fontSize = 22.sp, color = mainOrange, fontWeight = FontWeight.ExtraBold)
+            Text(
+                formatAmountOrMessage(savedPrice.toString()) + " 원",
+                fontSize = 22.sp,
+                color = mainOrange,
+                fontWeight = FontWeight.ExtraBold
+            )
             Divider(
                 modifier = Modifier.size(1.dp, 31.dp),
                 color = Color.Gray,
             )
-            Text(formatAmountOrMessage((savedPrice*0.6).toInt().toString())+" 원", fontSize = 22.sp, color = mainOrange, fontWeight = FontWeight.ExtraBold)
+            Text(
+                formatAmountOrMessage((savedPrice * 0.6).toInt().toString()) + " 원",
+                fontSize = 22.sp,
+                color = mainOrange,
+                fontWeight = FontWeight.ExtraBold
+            )
         }
     }
 }
@@ -234,12 +247,13 @@ fun MyPageUserProfile(
     if (isDialogOpen.value)
         BadgeDialog(onDismiss = { isDialogOpen.value = !isDialogOpen.value })
 }
+
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun BadgeDialog(
-    onDismiss:() -> Unit = {},
+    onDismiss: () -> Unit = {},
     viewModel: MyPageViewModel = hiltViewModel()
-){
+) {
     val pagerState = rememberPagerState(initialPage = 1)
     Dialog(
         onDismissRequest = onDismiss,
@@ -280,7 +294,8 @@ fun BadgeDialog(
             Spacer(
                 Modifier
                     .clickable(onClick = onDismiss)
-                    .padding(bottom = 100.dp))
+                    .padding(bottom = 100.dp)
+            )
             Box {
                 Box(
                     modifier = Modifier
@@ -314,7 +329,8 @@ fun BadgeDialog(
             Spacer(
                 Modifier
                     .clickable(onClick = onDismiss)
-                    .padding(bottom = 500.dp))
+                    .padding(bottom = 500.dp)
+            )
         }
     }
 }
@@ -346,18 +362,18 @@ fun Following(
     onFollowingClick: () -> Unit = {},
     Following: Int = 6,
     Follower: Int = 3
-){
+) {
     Box(
         modifier = Modifier
             .fillMaxWidth(0.9f)
             .height(56.dp)
             .clip(RoundedCornerShape(14.dp))
-    ){
+    ) {
         Row(
             modifier = Modifier.fillMaxSize(),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
-        ){
+        ) {
             Column(
                 modifier = Modifier
                     .weight(1f)
@@ -388,7 +404,7 @@ fun Following(
                     .clickable(onClick = onFollowerClick)
                     .weight(1f),
                 horizontalAlignment = Alignment.CenterHorizontally
-            ){
+            ) {
                 Text(
                     text = formatAmountOrMessage(Follower.toString()),
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/MyPage/MyPageState.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/MyPage/MyPageState.kt
@@ -3,11 +3,12 @@ package com.d_vide.D_VIDE.app.presentation.view.MyPage
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.BadgeRequestDTO
 import com.d_vide.D_VIDE.app.data.remote.responseDTO.BadgeDTO
 import com.d_vide.D_VIDE.app.data.remote.responseDTO.UserDTO
+import com.d_vide.D_VIDE.app.domain.model.UserInfo
 
 
 data class MyPageState(
     var isLoading: Boolean = false,
-    var userDTO: UserDTO = UserDTO(),
+    var userInfo: UserInfo = UserInfo(),
     var badgesDTO: List<BadgeDTO> = emptyList(),
     var badgeRequestDTO: BadgeRequestDTO = BadgeRequestDTO(),
     var error: String = ""

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/MyPage/MyPageViewModel.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/MyPage/MyPageViewModel.kt
@@ -4,16 +4,14 @@ import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.d_vide.D_VIDE.app.data.remote.requestDTO.BadgeRequestDTO
-import com.d_vide.D_VIDE.app.data.remote.responseDTO.BadgeDTO
 import com.d_vide.D_VIDE.app.domain.use_case.GetBadges
 import com.d_vide.D_VIDE.app.domain.use_case.PostBadge
 import com.d_vide.D_VIDE.app.domain.use_case.User.GetUserInfo
 import com.d_vide.D_VIDE.app.domain.util.Resource
 import com.d_vide.D_VIDE.app.domain.util.log
+import com.d_vide.D_VIDE.app.presentation.state.UserInformation
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,76 +20,67 @@ class MyPageViewModel @Inject constructor(
     val postBadgeUseCase: PostBadge,
     val getUserInfoUseCase: GetUserInfo,
 ) : ViewModel() {
-
     var state by mutableStateOf(MyPageState())
+        private set
     var badge by mutableStateOf("")
+        private set
+
+    var user by mutableStateOf(UserInformation.userInfo)
+        private set
 
     init {
         getUserInfo()
         getBadges()
     }
 
-    private fun counterPolicy(): SnapshotMutationPolicy<MyPageState?> =
-        object : SnapshotMutationPolicy<MyPageState?> {
-            override fun equivalent(a: MyPageState?, b: MyPageState?): Boolean {
-                if(a?.userDTO!!.badge == b?.userDTO!!.badge) return a.userDTO.badge == b.userDTO.badge
-                return a == b
-            }
-            override fun merge(
-                previous: MyPageState?,
-                current: MyPageState?,
-                applied: MyPageState?
-            ): MyPageState? = previous
-        }
-
     private fun getUserInfo() {
+        viewModelScope.launch {
+            getUserInfoUseCase().collect { result ->
+                when (result) {
+                    is Resource.Success -> {
+                        badge = UserInformation.userInfo.badge.name
 
-        getUserInfoUseCase().onEach { result ->
-            when (result) {
-                is Resource.Success -> {
-                    state.userDTO = result.data!!
-                    badge = result.data.badge.name
-
-                    "내 정보 가져오기 성공".log()
-                    "뱃지 이름 : ${badge}, ${result.data.badge.name}"
+                        "내 정보 가져오기 성공".log()
+                    }
+                    is Resource.Error -> "내 정보 가져오기 실패".log()
+                    is Resource.Loading -> "내 정보 가져오는 중".log()
                 }
-                is Resource.Error -> "내 정보 가져오기 실패".log()
-                is Resource.Loading -> "내 정보 가져오는 중".log()
             }
-        }.launchIn(viewModelScope)
+        }
     }
 
     fun getBadges() {
-
-        getBadgesUseCase().onEach { result ->
-            when (result) {
-                is Resource.Success -> {
-                    state = state?.copy(badgesDTO = result.data!!.badges)
-                    "${state!!.badgesDTO}".log()
-                    "뱃지 가져오기 성공".log()
+        viewModelScope.launch {
+            getBadgesUseCase().collect { result ->
+                when (result) {
+                    is Resource.Success -> {
+                        state = state.copy(badgesDTO = result.data!!.badges)
+                        "뱃지 가져오기 성공".log()
+                    }
+                    is Resource.Error -> "뱃지 가져오기 실패".log()
+                    is Resource.Loading -> "뱃지 가져오는 중".log()
                 }
-                is Resource.Error -> "뱃지 가져오기 실패".log()
-                is Resource.Loading -> "뱃지 가져오는 중".log()
             }
-        }.launchIn(viewModelScope)
-
+        }
     }
 
     fun postBadges(badgeName: String) {
         val badgeRequestDTO = BadgeRequestDTO(badgeName)
-        postBadgeUseCase(badgeRequestDTO).onEach {
-            when (it) {
-                is Resource.Success -> {
-                    getUserInfo()
-                    "뱃지 등록하기 성공".log()
+        viewModelScope.launch {
+            postBadgeUseCase(badgeRequestDTO).collect {
+                when (it) {
+                    is Resource.Success -> {
+                        getUserInfo()
+                        "뱃지 등록하기 성공".log()
+                    }
+                    is Resource.Error -> {
+                        getUserInfo()
+                        "뱃지 등록하기 실패".log()
+                    }
+                    is Resource.Loading -> "뱃지 등록하는 중".log()
                 }
-                is Resource.Error -> {
-                    getUserInfo()
-                    "뱃지 등록하기 실패".log()
-                }
-                is Resource.Loading -> "뱃지 등록하는 중".log()
             }
-        }.launchIn(viewModelScope)
+        }
     }
 
 }

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/Recruitings/RecruitingsScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/Recruitings/RecruitingsScreen.kt
@@ -80,10 +80,10 @@ fun RecruitingsScreen(
                                 Log.d("testProgress","${it.post.orderedPrice.toFloat()/it.post.targetPrice.toFloat()}")
                                 RecruitingItem(
                                     onUserClick = {
+                                        userId.value = it.user.id
+                                        userFeedViewModel.getOtherUserInfo(userId.value)
+                                        userFeedViewModel.getOtherUserReviews(userId.value)
                                         scope.launch {
-                                            userId.value = it.user.id
-                                            userFeedViewModel.getOtherUserInfo(userId.value)
-                                            userFeedViewModel.getOtherUserReviews(userId.value)
                                             state.animateTo(
                                                 ModalBottomSheetValue.Expanded,
                                                 tween(500)

--- a/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/UserFeed/UserFeedScreen.kt
+++ b/app/src/main/java/com/d_vide/D_VIDE/app/presentation/view/UserFeed/UserFeedScreen.kt
@@ -88,7 +88,8 @@ fun ColumnScope.UserFeedList(
     userId: Long,
     viewModel: UserReviewsViewModel = hiltViewModel()
 ) {
-    viewModel.getOtherUserReviews(userId)
+//     viewModel.getOtherUserReviews(userId)
+
     LazyColumn(
         modifier = Modifier.weight(1f),
         verticalArrangement = Arrangement.spacedBy(10.dp)

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,10 @@ plugins {
     id 'com.android.library' version '7.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.21'
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}
+//task clean(type: Delete) {
+//    delete rootProject.buildDir
+//}

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ plugins {
     id 'com.android.library' version '7.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
-    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.21'
+    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.21'
 }
 
 //task clean(type: Delete) {


### PR DESCRIPTION
```kotlin
object UserInformation {
    var userInfo: UserInfo = UserInfo()
    var token: String = ""
    var fcm: String = ""
}

data class UserInfo(
    var userId: Long = 0L,
    var email: String = "",
    var nickname: String = "",
    var badge: BadgeDTO = BadgeDTO(),
    var profileImgUrl: String = "",
    var followerCount: Int = 0,
    var followingCount: Int = 0,
    val carbonAmount: Int = 0,
    var savedPrice: Int = 0,
)
```
- 이제 토큰과 유저 정보와 같이 크게 변하지 않는 정보들은 UI 단에서 싱글톤으로 관리합니다.
- 관련 정보를 읽어올때에는 get과 같은 UseCase를 사용하지 않고 UserInformation으로 접근합니다.
- 관련 정보를 수정할 때에는 use case로 직접 수정하는 것이 아닌, 수정하는 유즈 케이스 내에서 reposiotry 로 정보를 수정하고, object에 반영해줍니다.

close #112 